### PR TITLE
grant grafana user access to the public schema to support postgres 15 and later versions

### DIFF
--- a/modules/aptible/main.tf
+++ b/modules/aptible/main.tf
@@ -113,6 +113,9 @@ resource "null_resource" "sessions_table" {
     command     = <<-EOT
       aptible ssh --environment ${data.aptible_environment.metrics.handle} --app ${aptible_app.psql.handle} sh -c "$(cat << EOF
         psql '${aptible_database.postgres.default_connection_url}' << EOQ
+          CREATE USER "${var.grafana_db_user}" WITH PASSWORD '${random_password.gf_db_password.result}';
+          GRANT ALL ON SCHEMA public TO "${var.grafana_db_user}";
+          
           CREATE DATABASE sessions;
           \c sessions;
 
@@ -123,8 +126,8 @@ resource "null_resource" "sessions_table" {
             PRIMARY KEY (key)
           );
 
-          CREATE USER "${var.grafana_db_user}" WITH PASSWORD '${random_password.gf_db_password.result}';
           GRANT ALL PRIVILEGES ON DATABASE db, sessions to "${var.grafana_db_user}";
+          GRANT ALL ON SCHEMA public TO "${var.grafana_db_user}";
       EOQ
       EOF
       )"


### PR DESCRIPTION
The release of PostgreSQL 15 removed "PUBLIC creation permission on the public schema" - https://www.postgresql.org/docs/15/release-15.html#id-1.11.6.5.5 - which blocked the grafana user created by the metrics module from creating the necessary tables. This change grants the necessary access on the `public` schema to allow the grafana user to make the necessary changes.