### PR TITLE
fix: update terraform to match changes for settings updates

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,28 +2,27 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/aptible/aptible" {
-  version     = "0.5.1"
-  constraints = "~> 0.5.1"
+  version     = "0.10.0"
+  constraints = "~> 0.10.0"
   hashes = [
-    "h1:F0eqNmuvfQrhpb2g7z4JzRbb1Xd2yV+GZ7gyaXHvrPw=",
-    "zh:198773e5f99d860a856d2c01c4a9155407e2f4bf12067307e0afd4e1686662c7",
-    "zh:53eaa46aaa04f5dbdad2fe73cfd4760084cd040ebbbec7b0ceac6eeb876008e9",
-    "zh:5f24099ab10adffcd7b1ef0b04829c632db0fab89d1bb137f419c997378f1b47",
-    "zh:7a1c4186f2d9652fdcf52a7cdd0f4f332bf0dfcef2d2dfa008fa6fe34f9afdcb",
-    "zh:94590fa54c682f6cf1f11d97bcd66f2cd738bcbeeb510f74651f3dc596b22000",
-    "zh:a18ad0999b4eea74445a5eacd2030062b733ac923ecad5603b368fac85bc4f2c",
-    "zh:a81f08081248d4193b872c1717b834b96766f9d03069905875029b31ee0d3f1f",
-    "zh:acc2509041135097326fd3349f6ff770cfed0ebd221ad03a0fe3ae2552680cbe",
-    "zh:c592dee8a3f4f1d8b74e7b3fa9cd21a13bca7dc6ea7345a839ddc35fbfb43346",
-    "zh:e54c5d097fd74d452813e9a88b398253c989a8709f4350609ff10da992990aa2",
-    "zh:ed76b4308dd103b4709b2efa67dba92fc968660337549098dccba0309b8182f2",
-    "zh:efbbf852852ef3d7c2b43ff9ebb1cf592369fc951ec621c8e887c0e5a38e2c0a",
+    "h1:OSnUmsxinitKt8FRhW68Ty+57uWCDrjBWoXN2KZE0WY=",
+    "zh:03bb1546a52b9d36ad2d273f8212a981ce50f55f636ac55de132afa1362b033e",
+    "zh:19330a2b676289f6546040a9edee78c76f244e8534c266b6ff05ba355e0c6cf8",
+    "zh:22c82711c41fc70287f7eaf8e17c62124ac850e3717dc1bc37b152e7d037f186",
+    "zh:34e3fb5ec9275beb8dedd2f96dd0ac4a32be2fb053603e9cbb60354730cd8650",
+    "zh:5c923fb7d4bceba0aaac5b48ff6bfd034f4a1318d225b81cedc36d0abf4aacdf",
+    "zh:60cec10bb5fe19437823352e08ae491cada733348d899778a51a4be0443c7575",
+    "zh:6523948e1adebb52f283b8b63865b25ccb871b45db2184b09b75913469614fcf",
+    "zh:7e85de04bc346313a18439602a88b4f15769d0b693b51a6cf087d9aae82916cb",
+    "zh:9d2dc69981ce49269b352b7af54ab97585513e81905bc65d7ab43a8540bd8926",
+    "zh:d10d0689035d573cfcd89f557469061509ce086be62fe3ffdefac232e2f72b99",
+    "zh:dd119731669ffc30ec6ff8f21450f750db71f3b65f0adad7c66143d5ceb72336",
   ]
 }
 
 provider "registry.terraform.io/grafana/grafana" {
   version     = "1.29.0"
-  constraints = "1.29.0"
+  constraints = "~> 1.29.0"
   hashes = [
     "h1:gAwjLPim8o9Yq3pio3YnhmzDU0wRwhe9iKhPdBj5KYw=",
     "zh:068ec344f60d148bf23c9e0ce41bb48e919192339b7332d17b151ff65e0064a4",
@@ -45,7 +44,7 @@ provider "registry.terraform.io/grafana/grafana" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.1.1"
-  constraints = "3.1.1"
+  constraints = "~> 3.1.0"
   hashes = [
     "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
     "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
@@ -65,7 +64,7 @@ provider "registry.terraform.io/hashicorp/null" {
 
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.4.3"
-  constraints = "3.4.3"
+  constraints = "~> 3.4.0"
   hashes = [
     "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
     "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ includes two submodules for managing resources:
 This module is responsible for managing the Aptible resources (and the Grafana
 data source) necessary to collect and store container metrics.
 
+See the `examples` directory for recommended usages of this module. 
+
 ### Dependencies
 
 This module depends on the 

--- a/examples/multiple_environments/main.tf
+++ b/examples/multiple_environments/main.tf
@@ -5,3 +5,13 @@ module "aptible_metrics" {
   metrics_environment = "my-metrics"
   drain_environments  = ["my-metrics", "my-env", "my-other-env"]
 }
+
+output "grafana_url" {
+  value     = module.aptible_metrics.aptible.grafana_url
+  sensitive = true
+}
+
+output "grafana_auth" {
+  value     = module.aptible_metrics.aptible.grafana_auth
+  sensitive = true
+}

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -4,3 +4,13 @@ module "aptible_metrics" {
   source              = "../../"
   metrics_environment = "my-env"
 }
+
+output "grafana_url" {
+  value     = module.aptible_metrics.aptible.grafana_url
+  sensitive = true
+}
+
+output "grafana_auth" {
+  value     = module.aptible_metrics.aptible.grafana_auth
+  sensitive = true
+}

--- a/modules/aptible/README.md
+++ b/modules/aptible/README.md
@@ -14,7 +14,7 @@ PostgreSQL Database to manage Grafana sessions.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aptible"></a> [aptible](#requirement\_aptible) | ~> 0.8.1 |
+| <a name="requirement_aptible"></a> [aptible](#requirement\_aptible) | ~> 0.10.0 |
 | <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | ~> 1.29.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4.0 |
@@ -23,7 +23,7 @@ PostgreSQL Database to manage Grafana sessions.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aptible"></a> [aptible](#provider\_aptible) | ~> 0.8.1 |
+| <a name="provider_aptible"></a> [aptible](#provider\_aptible) | ~> 0.10.0 |
 | <a name="provider_grafana"></a> [grafana](#provider\_grafana) | ~> 1.29.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.0 |

--- a/modules/aptible/main.tf
+++ b/modules/aptible/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aptible = {
       source  = "aptible/aptible"
-      version = "~> 0.8.1"
+      version = "~> 0.10.0"
     }
     grafana = {
       source  = "grafana/grafana"
@@ -90,14 +90,12 @@ resource "random_password" "gf_secret_key" {
 # Some providers exist to create database objects but we don't have a way to set
 # up the tunnel in order to reach the database so use an Aptible App
 resource "aptible_app" "psql" {
-  env_id = data.aptible_environment.metrics.env_id
-  handle = "psql-${data.aptible_environment.metrics.handle}"
+  env_id       = data.aptible_environment.metrics.env_id
+  handle       = "psql-${data.aptible_environment.metrics.handle}"
+  docker_image = "postgres:alpine"
   service {
     process_type    = "cmd"
     container_count = 0
-  }
-  config = {
-    "APTIBLE_DOCKER_IMAGE" = "postgres:alpine"
   }
 }
 
@@ -156,8 +154,9 @@ resource "aptible_metric_drain" "this" {
 
 # Apps
 resource "aptible_app" "grafana" {
-  env_id = data.aptible_environment.metrics.env_id
-  handle = var.grafana_handle
+  env_id       = data.aptible_environment.metrics.env_id
+  handle       = var.grafana_handle
+  docker_image = "grafana/grafana:${var.grafana_image_tag}"
   service {
     process_type           = "cmd"
     container_count        = var.grafana_container_count
@@ -165,8 +164,6 @@ resource "aptible_app" "grafana" {
     container_profile      = var.grafana_container_profile
   }
   config = {
-    "APTIBLE_DOCKER_IMAGE"       = "grafana/grafana:${var.grafana_image_tag}"
-    "FORCE_SSL"                  = "true"
     "GF_SECURITY_ADMIN_PASSWORD" = random_password.gf_admin_password.result
     "GF_SECURITY_SECRET_KEY"     = random_password.gf_secret_key.result
     "GF_DEFAULT_INSTANCE_NAME"   = "aptible"
@@ -194,6 +191,7 @@ resource "aptible_endpoint" "grafana_endpoint" {
   endpoint_type  = "https"
   managed        = var.grafana_endpoint_domain != null
   platform       = "alb"
+  force_ssl      = true
 }
 
 # Grafana data source


### PR DESCRIPTION
This should make this set of modules compatible with these changes: https://github.com/aptible/terraform-provider-aptible/releases/tag/v0.10.0

---

Evidence of function:

## Plan

<img width="519" height="239" alt="image" src="https://github.com/user-attachments/assets/cc58756b-ea3c-4763-a646-1056c6d2fb80" />

## Apply

It does appear to work but there seems to be a bug on the default branch of the grafana terraform provider:

> │ When applying changes to module.aptible.grafana_data_source.influx, provider "module.aptible.provider[\"registry.terraform.io/grafana/grafana\"]" produced an unexpected new value: Root object was present, but now absent.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.

<img width="1575" height="122" alt="image" src="https://github.com/user-attachments/assets/5494e336-d745-42fa-a312-58b9d3aa41db" />

This also appears to me on main:

<img width="1791" height="149" alt="image" src="https://github.com/user-attachments/assets/50a84185-c261-4a42-9634-8bef36b95ab1" />

## Verification of func

<img width="621" height="424" alt="image" src="https://github.com/user-attachments/assets/51f2352c-c67c-49d9-9c9c-b543f377fda2" />